### PR TITLE
Support building a custom tronbyt-server fork from source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.17
+- Added `custom_server_repo` and `custom_server_ref` options. When set, the Tronbyt Server binary is built from source (mirroring the upstream Dockerfile's CGo + libwebp + `gzip_fonts` build) on startup and replaces the bundled upstream build.
+- Compiled binaries are cached under `/data/tronbyt-build/cache/<commit>/`, so repeat starts on the same commit skip the build entirely; the three most recent builds are retained.
+- Added `git` to the runtime image to support cheap ref resolution via `git ls-remote` before deciding whether to rebuild.
+
 ## 0.1.16
 - Bumped upstream `tronbyt/server` from `2.2.7` to `2.2.8`.
 - Rebuilt and published updated app images for `amd64` and `aarch64`.

--- a/DOCS.md
+++ b/DOCS.md
@@ -35,10 +35,15 @@ Example: `http://192.168.1.100:8000` (if host port is set to `8000`)
 | `single_user_auto_login` | `false` | Automatically signs in a single-user setup. |
 | `github_token` | `""` | GitHub token used when accessing private app repositories. |
 | `system_apps_repo` | `""` | Optional Git URL for a custom system apps repository. |
+| `custom_server_repo` | `""` | Optional Git URL for a custom Tronbyt Server fork. When set, the binary is built from source on startup instead of using the bundled upstream build. |
+| `custom_server_ref` | `""` | Branch, tag, or commit SHA to check out from `custom_server_repo`. Defaults to the repository's default branch when empty. |
 
 Notes:
 - Keep `enable_user_registration` disabled unless you specifically need it.
 - `github_token` is optional and only needed for private repositories.
+- `custom_server_repo` is intended for forks of [`tronbyt/server`](https://github.com/tronbyt/server). The fork must keep the same project layout (Go module with a `./cmd/server` entrypoint and CGo + libwebp dependencies).
+- The first build with a new repo or ref can take several minutes — the addon installs build dependencies and compiles Go from source. Builds are cached under `/data/tronbyt-build/cache/<commit>/`; restarts on the same commit reuse the cached binary. The three most recent builds are retained.
+- Clear `custom_server_repo` to revert to the bundled upstream binary on the next restart.
 
 ## Network
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ FROM alpine:3.21
 
 # Install runtime dependencies
 #   `jq` used for parsing Home Assistant options.json
-RUN apk add --no-cache jq ca-certificates tzdata dos2unix
+#   `git` used to resolve refs for an optional custom server fork (build-from-source flow in run.sh)
+RUN apk add --no-cache jq ca-certificates tzdata dos2unix git
 
 # Copy everything from /app in the tronbyt image (binary + static assets)
 COPY --from=tronbyt /app/ /app/

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: "Tronbyt Server"
-version: "0.1.16"
+version: "0.1.17"
 slug: "tronbyt_server"
 description: "Manage your apps on your Tronbyt (flashed Tidbyt) completely locally without relying on Tidbyt's backend servers."
 arch:
@@ -21,12 +21,16 @@ options:
   single_user_auto_login: false
   github_token: ""
   system_apps_repo: ""
+  custom_server_repo: ""
+  custom_server_ref: ""
 schema:
   production: bool
   enable_user_registration: bool
   single_user_auto_login: bool
   github_token: "password?"
   system_apps_repo: "str?"
+  custom_server_repo: "str?"
+  custom_server_ref: "str?"
 image: "ghcr.io/kaffolder7/{arch}-app-tronbyt-server"
 panel_icon: "mdi:server-network"
 

--- a/config.yaml
+++ b/config.yaml
@@ -31,7 +31,6 @@ schema:
   system_apps_repo: "str?"
   custom_server_repo: "str?"
   custom_server_ref: "str?"
-image: "ghcr.io/kaffolder7/{arch}-app-tronbyt-server"
 panel_icon: "mdi:server-network"
 
 # Let Docker init handle zombie reaping (Tronbyt’s own compose uses init: true)

--- a/run.sh
+++ b/run.sh
@@ -14,6 +14,8 @@ ENABLE_USER_REGISTRATION=false
 SINGLE_USER_AUTO_LOGIN=false
 GITHUB_TOKEN=""
 SYSTEM_APPS_REPO=""
+CUSTOM_SERVER_REPO=""
+CUSTOM_SERVER_REF=""
 
 if [ -f "$OPTIONS_FILE" ]; then
   echo "[Tronbyt App] Reading configuration from options.json"
@@ -23,6 +25,8 @@ if [ -f "$OPTIONS_FILE" ]; then
   SINGLE_USER_AUTO_LOGIN=$(jq -r '.single_user_auto_login // false' "$OPTIONS_FILE")
   GITHUB_TOKEN=$(jq -r '.github_token // ""' "$OPTIONS_FILE")
   SYSTEM_APPS_REPO=$(jq -r '.system_apps_repo // ""' "$OPTIONS_FILE")
+  CUSTOM_SERVER_REPO=$(jq -r '.custom_server_repo // ""' "$OPTIONS_FILE")
+  CUSTOM_SERVER_REF=$(jq -r '.custom_server_ref // ""' "$OPTIONS_FILE")
 fi
 
 # ---------------------------------------------------------------
@@ -53,6 +57,120 @@ redact_url_credentials() {
 }
 
 # ---------------------------------------------------------------
+# Optional: build a custom tronbyt-server fork from source.
+#
+# When `custom_server_repo` is set, resolve the requested ref to a
+# commit and look for a cached binary in /data/tronbyt-build/cache.
+# On a cache miss, install build deps, clone, and `go build` with the
+# same flags as the upstream Dockerfile. The compiled binary then
+# replaces /app/tronbyt-server.
+# ---------------------------------------------------------------
+resolve_remote_commit() {
+  repo="$1"
+  ref="$2"
+
+  # If ref looks like a commit SHA, use it directly.
+  if printf '%s' "$ref" | grep -Eq '^[0-9a-f]{7,40}$'; then
+    echo "$ref"
+    return 0
+  fi
+
+  if [ -z "$ref" ]; then
+    git ls-remote --exit-code "$repo" HEAD 2>/dev/null | head -n1 | awk '{print $1}'
+    return $?
+  fi
+
+  # Try the ref as given, then as a branch, then as a tag.
+  out=$(git ls-remote --exit-code "$repo" "$ref" 2>/dev/null | head -n1 | awk '{print $1}') || out=""
+  if [ -z "$out" ]; then
+    out=$(git ls-remote --exit-code "$repo" "refs/heads/$ref" 2>/dev/null | head -n1 | awk '{print $1}') || out=""
+  fi
+  if [ -z "$out" ]; then
+    out=$(git ls-remote --exit-code "$repo" "refs/tags/$ref" 2>/dev/null | head -n1 | awk '{print $1}') || out=""
+  fi
+  echo "$out"
+}
+
+build_custom_server() {
+  repo="$1"
+  ref="$2"
+  build_root="/data/tronbyt-build"
+  cache_root="$build_root/cache"
+  src_dir="$build_root/src"
+
+  mkdir -p "$cache_root"
+
+  target_commit=$(resolve_remote_commit "$repo" "$ref")
+  if [ -z "$target_commit" ]; then
+    echo "[Tronbyt App] ERROR: could not resolve ref '${ref:-HEAD}' in $(redact_url_credentials "$repo")" >&2
+    return 1
+  fi
+  echo "[Tronbyt App] Custom fork target commit: $target_commit"
+
+  cached_binary="$cache_root/$target_commit/tronbyt-server"
+
+  if [ -x "$cached_binary" ]; then
+    echo "[Tronbyt App] Using cached build for $target_commit"
+  else
+    echo "[Tronbyt App] No cached build for $target_commit; building from source..."
+    echo "[Tronbyt App] (This may take several minutes on first run.)"
+
+    # Build deps mirror the upstream Dockerfile (CGo + libwebp).
+    apk add --no-cache build-base clang go libwebp-dev libwebp-static >/dev/null
+
+    if [ -d "$src_dir/.git" ]; then
+      git -C "$src_dir" remote set-url origin "$repo"
+    else
+      rm -rf "$src_dir"
+      mkdir -p "$src_dir"
+      git -C "$src_dir" init -q
+      git -C "$src_dir" remote add origin "$repo"
+    fi
+
+    # Try a shallow fetch of the exact commit first; fall back to ref name,
+    # then a full fetch if the remote doesn't allow fetching by SHA.
+    if ! git -C "$src_dir" fetch --depth=1 origin "$target_commit" 2>/dev/null; then
+      if [ -n "$ref" ] && git -C "$src_dir" fetch --depth=1 origin "$ref" 2>/dev/null; then
+        :
+      else
+        git -C "$src_dir" fetch origin
+      fi
+    fi
+
+    git -C "$src_dir" checkout -q "$target_commit"
+
+    mkdir -p "$cache_root/$target_commit"
+    (
+      cd "$src_dir"
+      # GOTOOLCHAIN=auto lets the system Go bootstrap the version pinned in go.mod.
+      export GOTOOLCHAIN=auto
+      export CGO_ENABLED=1
+      go build \
+        -ldflags="-w -s -extldflags '-static'" \
+        -tags gzip_fonts \
+        -o "$cached_binary" \
+        ./cmd/server
+    )
+
+    chmod +x "$cached_binary"
+    echo "[Tronbyt App] Build complete: $cached_binary"
+  fi
+
+  cp "$cached_binary" /app/tronbyt-server
+  chmod +x /app/tronbyt-server
+
+  # Keep only the three newest cached builds so /data doesn't grow unbounded.
+  ls -1t "$cache_root" 2>/dev/null | tail -n +4 | while read -r old; do
+    [ -n "$old" ] && rm -rf "$cache_root/$old"
+  done
+}
+
+if [ -n "$CUSTOM_SERVER_REPO" ] && [ "$CUSTOM_SERVER_REPO" != "null" ]; then
+  echo "[Tronbyt App] Custom server fork enabled: $(redact_url_credentials "$CUSTOM_SERVER_REPO") (ref: ${CUSTOM_SERVER_REF:-HEAD})"
+  build_custom_server "$CUSTOM_SERVER_REPO" "$CUSTOM_SERVER_REF"
+fi
+
+# ---------------------------------------------------------------
 # Set up persistent data storage
 # ---------------------------------------------------------------
 # HA apps persist /data across restarts.
@@ -79,6 +197,12 @@ if [ -n "$SYSTEM_APPS_REPO" ] && [ "$SYSTEM_APPS_REPO" != "null" ]; then
   echo "  SYSTEM_APPS_REPO=$(redact_url_credentials "$SYSTEM_APPS_REPO")"
 else
   echo "  SYSTEM_APPS_REPO=<default>"
+fi
+if [ -n "$CUSTOM_SERVER_REPO" ] && [ "$CUSTOM_SERVER_REPO" != "null" ]; then
+  echo "  CUSTOM_SERVER_REPO=$(redact_url_credentials "$CUSTOM_SERVER_REPO")"
+  echo "  CUSTOM_SERVER_REF=${CUSTOM_SERVER_REF:-HEAD}"
+else
+  echo "  CUSTOM_SERVER_REPO=<bundled>"
 fi
 echo "  Data directory: $PERSISTENT_DIR"
 echo ""

--- a/translations/de.yaml
+++ b/translations/de.yaml
@@ -20,5 +20,11 @@ configuration:
     name: System-Apps-Repository
     # description: Git-URL zu Ihrem System-App-Repository.
     description: Geben Sie die Git-Repository-URL für Systemanwendungen an.
+  custom_server_repo:
+    name: Eigenes Server-Fork-Repository
+    description: Optionale Git-URL für einen Fork des Tronbyt-Servers. Wenn gesetzt, wird der Server beim Start aus dem Quellcode kompiliert, anstatt den mitgelieferten Upstream-Build zu verwenden.
+  custom_server_ref:
+    name: Eigene Server-Fork-Referenz
+    description: Branch, Tag oder Commit-SHA, der aus dem eigenen Server-Repository ausgecheckt wird. Wenn leer, wird der Standard-Branch des Repositorys verwendet.
 network:
   8000/tcp: Tronbyt Web-Benutzeroberfläche/LAN-Zugriff (Standard-Host-Port: 8000)

--- a/translations/en.yaml
+++ b/translations/en.yaml
@@ -20,5 +20,11 @@ configuration:
     name: System Apps Repository
     # description: Git URL to your system apps repository.
     description: Specify Git repository URL for system apps.
+  custom_server_repo:
+    name: Custom Server Fork Repository
+    description: Optional Git URL for a Tronbyt Server fork. When set, the server is built from source on startup instead of using the bundled upstream build.
+  custom_server_ref:
+    name: Custom Server Fork Ref
+    description: Branch, tag, or commit SHA to check out from the custom server repository. Defaults to the repository's default branch when empty.
 network:
   8000/tcp: Tronbyt Web UI/LAN access (default host port: 8000)

--- a/translations/es.yaml
+++ b/translations/es.yaml
@@ -20,5 +20,11 @@ configuration:
     name: Repositorio de aplicaciones del sistema
     # description: URL de Git del repositorio de las aplicaciones de su sistema.
     description: Especifique la URL del repositorio de Git para las aplicaciones del sistema.
+  custom_server_repo:
+    name: Repositorio del fork del servidor personalizado
+    description: URL de Git opcional para un fork del servidor Tronbyt. Cuando se establece, el servidor se compila desde el código fuente al arrancar en lugar de usar la versión incluida.
+  custom_server_ref:
+    name: Referencia del fork del servidor personalizado
+    description: Rama, etiqueta o SHA del commit a usar del repositorio del servidor personalizado. Si se deja vacío, se usa la rama predeterminada del repositorio.
 network:
   8000/tcp: UI web/acceso LAN de Tronbyt (puerto de host predeterminado: 8000)


### PR DESCRIPTION
Adds custom_server_repo and custom_server_ref options.

When set, run.sh resolves the ref via git ls-remote, builds with the same CGo + libwebp + gzip_fonts flags as upstream's Dockerfile, and caches the binary under /data/tronbyt-build/cache/<commit>/ so repeat starts on the same commit skip the build.

Bumps app to 0.1.17 and adds git to the runtime image for cheap ref resolution.